### PR TITLE
Added command_line_options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ A description of the settable variables for this role should go here, including 
 - **port_sequence**: array of ports that builds the knocking sequence (Example: *[24334,34534,2287]*) **Mandatory**
 - **secure_ports**: array of ports to enable after a successful knocking sequence (Example: *[22]*) **Mandatory**
 - **open_ports**: array of ports always available (Example: *[80, 443]*) (Default: [])
+*) **Mandatory**
+- **command_line_options**: string KNOCKD_OPTS configuration (Example: "-i ens3")
 - sequence_timeout: number of seconds to be able to introduce the knocking sequence (Default: 15)
 - command_timeout: number of seconds to be able to introduce a command (Default: 20)
 
@@ -40,7 +42,7 @@ This is an example of role configuration:
 
     - hosts: servers
       roles:
-         - { role: fcsonline.ansible-port-knocking, port_sequence: [24334,34534,2287], secure_ports: [22], open_ports: [80, 443] }
+         - { role: fcsonline.ansible-port-knocking, port_sequence: [24334,34534,2287], secure_ports: [22], open_ports: [80, 443], command_line_options: "-i ens3" }
 
 
 License

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ A description of the settable variables for this role should go here, including 
 
 - **port_sequence**: array of ports that builds the knocking sequence (Example: *[24334,34534,2287]*) **Mandatory**
 - **secure_ports**: array of ports to enable after a successful knocking sequence (Example: *[22]*) **Mandatory**
-- **open_ports**: array of ports always available (Example: *[80, 443]*) (Default: [])
-*) **Mandatory**
-- **command_line_options**: string KNOCKD_OPTS configuration (Example: "-i ens3")
+- **open_ports**: array of ports always available (Example: *[80, 443]*) (Default: []) **Mandatory**
+- **command_line_options**: string KNOCKD_OPTS configuration (Example: "-i ens3") **Mandatory**
 - sequence_timeout: number of seconds to be able to introduce the knocking sequence (Default: 15)
 - command_timeout: number of seconds to be able to introduce a command (Default: 20)
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ A description of the settable variables for this role should go here, including 
 
 - **port_sequence**: array of ports that builds the knocking sequence (Example: *[24334,34534,2287]*) **Mandatory**
 - **secure_ports**: array of ports to enable after a successful knocking sequence (Example: *[22]*) **Mandatory**
-- **open_ports**: array of ports always available (Example: *[80, 443]*) (Default: []) **Mandatory**
 - **command_line_options**: string KNOCKD_OPTS configuration (Example: "-i ens3") **Mandatory**
+- **open_ports**: array of ports always available (Example: *[80, 443]*) (Default: [])
 - sequence_timeout: number of seconds to be able to introduce the knocking sequence (Default: 15)
 - command_timeout: number of seconds to be able to introduce a command (Default: 20)
 

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -8,6 +8,10 @@
          multiport: " -m multiport "
      when: secure_ports|length > 1
 
+   - name: writes the /etc/default/knockd
+     template: src=templates/knockd.j2 dest=/etc/default/knockd mode=0400
+     notify: start knockd
+
    - name: writes the knockd conf
      template: src=templates/knockd.conf.j2 dest=/etc/knockd.conf mode=0640
      notify: start knockd
@@ -34,7 +38,3 @@
 
    - name: start netfilter
      service: name=netfilter-persistent state=started
-
-   - name: enable knockd conf
-     replace: dest=/etc/default/knockd regexp='^(START_KNOCKD=)0$' replace='\g<1>1'
-     notify: restart knockd

--- a/templates/knockd.j2
+++ b/templates/knockd.j2
@@ -1,0 +1,8 @@
+# control if we start knockd at init or not
+# 1 = start
+# anything else = don't start
+# PLEASE EDIT /etc/knockd.conf BEFORE ENABLING
+START_KNOCKD=1
+
+# command line options
+KNOCKD_OPTS="{{ command_line_options }}"


### PR DESCRIPTION
1. Removed replace START_KNOCKD in /etc/default/knockd file.
2. Added /etc/default/knockd template.
3. Added command_line_options parameter for KNOCKD_OPTS.
4. Change README file.