### PR TITLE
fix(ansible): Make the role Ansible 2.16+ compatible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-  - include: packages.yml
-  - include: services.yml
+  - ansible.builtin.import_tasks: packages.yml
+  - ansible.builtin.import_tasks: services.yml


### PR DESCRIPTION
Since the ansible.builtin.include module has been removed from Ansible 2.16, the best fitting alternative for the usecase in this role is `import_tasks`.

https://docs.ansible.com/ansible/5/collections/ansible/builtin/include_module.html